### PR TITLE
Feature/tooltips

### DIFF
--- a/src/main/java/com/eeveebeby/farmersdelight_extended/item/ModFoodProperties.java
+++ b/src/main/java/com/eeveebeby/farmersdelight_extended/item/ModFoodProperties.java
@@ -149,6 +149,7 @@ public class ModFoodProperties {
             .nutrition(14).saturationModifier(.4f).alwaysEdible().build();
     public static final FoodProperties GOLDEN_APPLE_CIDER = new FoodProperties.Builder()
             .effect(() -> new MobEffectInstance(MobEffects.ABSORPTION, 2400, 1), 1)
+            .alwaysEdible()
             .build();
     public static final FoodProperties BROWNIE = new FoodProperties.Builder()
             .nutrition(8).saturationModifier(.6f)

--- a/src/main/java/com/eeveebeby/farmersdelight_extended/item/ModItems.java
+++ b/src/main/java/com/eeveebeby/farmersdelight_extended/item/ModItems.java
@@ -18,7 +18,7 @@ public class ModItems {
 
     // Group 1
     public static final DeferredItem<Item> BATTERED_COD = ITEMS.register("battered_cod",
-            () -> new Item(new Item.Properties().food(ModFoodProperties.BATTERED_COD)));
+            () -> new TooltipFoodItem(new Item.Properties().food(ModFoodProperties.BATTERED_COD)));
     public static final DeferredItem<Item> FRIED_COD = ITEMS.register("fried_cod",
             () -> new Item(new Item.Properties().food(ModFoodProperties.FRIED_COD)));
 
@@ -28,7 +28,7 @@ public class ModItems {
     public static final DeferredItem<Item> FRIES = ITEMS.register("fries",
             () -> new Item(new Item.Properties().food(ModFoodProperties.FRIES)));
     public static final DeferredItem<Item> FISH_AND_CHIPS = ITEMS.register("fish_and_chips",
-            () -> new Item(new Item.Properties().food(ModFoodProperties.FISH_AND_CHIPS).stacksTo(16).craftRemainder(Items.BOWL)));
+            () -> new TooltipFoodItem(new Item.Properties().food(ModFoodProperties.FISH_AND_CHIPS).stacksTo(16).craftRemainder(Items.BOWL)));
     public static final DeferredItem<Item> HONEY_ROLL = ITEMS.register("honey_roll",
             () -> new Item(new Item.Properties().food(ModFoodProperties.HONEY_ROLL)));
     public static final DeferredItem<Item> CHOCOLATE_ROLL = ITEMS.register("chocolate_roll",
@@ -38,11 +38,11 @@ public class ModItems {
     public static final DeferredItem<Item> TOAST = ITEMS.register("toast",
             () -> new Item(new Item.Properties().food(ModFoodProperties.TOAST)));
     public static final DeferredItem<Item> BATTERED_CHICKEN = ITEMS.register("battered_chicken",
-            () -> new Item(new Item.Properties().food(ModFoodProperties.BATTERED_CHICKEN)));
+            () -> new TooltipFoodItem(new Item.Properties().food(ModFoodProperties.BATTERED_CHICKEN)));
     public static final DeferredItem<Item> FRIED_CHICKEN = ITEMS.register("fried_chicken",
             () -> new Item(new Item.Properties().food(ModFoodProperties.FRIED_CHICKEN)));
     public static final DeferredItem<Item> CHICKEN_AND_FRIES = ITEMS.register("chicken_and_fries",
-            () -> new Item(new Item.Properties().food(ModFoodProperties.CHICKEN_AND_FRIES).stacksTo(16).craftRemainder(Items.BOWL)));
+            () -> new TooltipFoodItem(new Item.Properties().food(ModFoodProperties.CHICKEN_AND_FRIES).stacksTo(16).craftRemainder(Items.BOWL)));
 
     // Group 3
     public static final DeferredItem<Item> FRESH_CHEESE = ITEMS.register("fresh_cheese",
@@ -50,9 +50,9 @@ public class ModItems {
     public static final DeferredItem<Item> CHEESEBURGER = ITEMS.register("cheeseburger",
             () -> new Item(new Item.Properties().food(ModFoodProperties.CHEESEBURGER)));
     public static final DeferredItem<Item> CHICKEN_PARMESAN = ITEMS.register("chicken_parmesan",
-            () -> new Item(new Item.Properties().food(ModFoodProperties.CHICKEN_PARMESAN).stacksTo(16).craftRemainder(Items.BOWL)));
+            () -> new TooltipFoodItem(new Item.Properties().food(ModFoodProperties.CHICKEN_PARMESAN).stacksTo(16).craftRemainder(Items.BOWL)));
     public static final DeferredItem<Item> BEEF_WELLINGTON = ITEMS.register("beef_wellington",
-            () -> new Item(new Item.Properties().food(ModFoodProperties.BEEF_WELLINGTON).stacksTo(16).craftRemainder(Items.BOWL)));
+            () -> new TooltipFoodItem(new Item.Properties().food(ModFoodProperties.BEEF_WELLINGTON).stacksTo(16).craftRemainder(Items.BOWL)));
     public static final DeferredItem<Item> SPICY_FRIED_CHICKEN = ITEMS.register("spicy_fried_chicken",
             () -> new SpicyFoodItem(new Item.Properties().food(ModFoodProperties.SPICY_FRIED_CHICKEN)));
     public static final DeferredItem<Item> SPICY_CHICKEN_AND_FRIES = ITEMS.register("spicy_chicken_and_fries",
@@ -62,13 +62,13 @@ public class ModItems {
     public static final DeferredItem<Item> HASHBROWNS = ITEMS.register("hashbrowns",
             () -> new Item(new Item.Properties().food(ModFoodProperties.HASHBROWNS)));
     public static final DeferredItem<Item> BREAKFAST_PLATE = ITEMS.register("breakfast_plate",
-            () -> new Item(new Item.Properties().food(ModFoodProperties.BREAKFAST_PLATE).stacksTo(16).craftRemainder(Items.BOWL)));
+            () -> new TooltipFoodItem(new Item.Properties().food(ModFoodProperties.BREAKFAST_PLATE).stacksTo(16).craftRemainder(Items.BOWL)));
 
     //Group 4
     public static final DeferredItem<Item> CHORUS_COOKIE = ITEMS.register("chorus_cookie",
             () -> new ChorusFoodItem(new Item.Properties().food(ModFoodProperties.CHORUS_COOKIE)));
     public static final DeferredItem<Item> GLOW_BERRY_COOKIE = ITEMS.register("glow_berry_cookie",
-            () -> new Item(new Item.Properties().food(ModFoodProperties.GLOW_BERRY_COOKIE)));
+            () -> new TooltipFoodItem(new Item.Properties().food(ModFoodProperties.GLOW_BERRY_COOKIE)));
     public static final DeferredItem<Item> CHORUS_POPSICLE = ITEMS.register("chorus_popsicle",
             () -> new ChorusFrozenItem(new Item.Properties().food(ModFoodProperties.CHORUS_POPSICLE)));
     public static final DeferredItem<Item> GLOW_BERRY_POPSICLE = ITEMS.register("glow_berry_popsicle",
@@ -121,9 +121,9 @@ public class ModItems {
     public static final DeferredItem<Item> BROWNIE = ITEMS.register("brownie",
             () -> new Item(new Item.Properties().food(ModFoodProperties.BROWNIE)));
     public static final DeferredItem<Item> BROWNIE_BATTER = ITEMS.register("brownie_batter",
-            () -> new Item(new Item.Properties().food(ModFoodProperties.BROWNIE_BATTER)));
+            () -> new TooltipFoodItem(new Item.Properties().food(ModFoodProperties.BROWNIE_BATTER)));
     public static final DeferredItem<Item> BATTERED_MUSHROOM = ITEMS.register("battered_mushroom",
-            () -> new Item(new Item.Properties().food(ModFoodProperties.BATTERED_MUSHROOM)));
+            () -> new TooltipFoodItem(new Item.Properties().food(ModFoodProperties.BATTERED_MUSHROOM)));
     public static final DeferredItem<Item> FRIED_MUSHROOM = ITEMS.register("fried_mushroom",
             () -> new Item(new Item.Properties().food(ModFoodProperties.FRIED_MUSHROOM)));
 //     public static final DeferredItem<Item> SPECIAL_BROWNIE = ITEMS.register("special_brownie",

--- a/src/main/java/com/eeveebeby/farmersdelight_extended/item/custom_properties/ChorusFoodItem.java
+++ b/src/main/java/com/eeveebeby/farmersdelight_extended/item/custom_properties/ChorusFoodItem.java
@@ -1,10 +1,17 @@
 package com.eeveebeby.farmersdelight_extended.item.custom_properties;
 
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.ChorusFruitItem;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public class ChorusFoodItem extends ChorusFruitItem {
     public ChorusFoodItem(Properties pProperties) {
@@ -14,5 +21,25 @@ public class ChorusFoodItem extends ChorusFruitItem {
     @Override
     public @NotNull ItemStack finishUsingItem(@NotNull ItemStack pStack, @NotNull Level pLevel, @NotNull LivingEntity pEntity) {
         return super.finishUsingItem(pStack, pLevel, pEntity);
+    }
+
+    @Override
+    public void appendHoverText(@NotNull ItemStack stack, @NotNull TooltipContext ctx, @NotNull List<Component> tooltip, @NotNull TooltipFlag flag) {
+        super.appendHoverText(stack, ctx, tooltip, flag);
+
+        FoodProperties food = this.getFoodProperties(stack, null);
+        if (food == null) return;
+
+        food.effects().forEach(possibleEffect -> {
+            MobEffectInstance effect = possibleEffect.effect();
+            float chance = possibleEffect.probability();
+
+            Component line = Component.translatable(effect.getDescriptionId())
+                    .append(" ")
+                    .append(Component.literal("(" + (effect.getDuration() / 20) + "s)"))
+                    .withStyle(ChatFormatting.BLUE);
+
+            tooltip.add(line);
+        });
     }
 }

--- a/src/main/java/com/eeveebeby/farmersdelight_extended/item/custom_properties/ChorusFrozenItem.java
+++ b/src/main/java/com/eeveebeby/farmersdelight_extended/item/custom_properties/ChorusFrozenItem.java
@@ -1,11 +1,18 @@
 package com.eeveebeby.farmersdelight_extended.item.custom_properties;
 
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.ChorusFruitItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public class ChorusFrozenItem extends ChorusFruitItem {
     private static final int FREEZING_DURATION = 135;
@@ -27,5 +34,25 @@ public class ChorusFrozenItem extends ChorusFruitItem {
         }
 
         return resultStack;
+    }
+
+    @Override
+    public void appendHoverText(@NotNull ItemStack stack, @NotNull TooltipContext ctx, @NotNull List<Component> tooltip, @NotNull TooltipFlag flag) {
+        super.appendHoverText(stack, ctx, tooltip, flag);
+
+        FoodProperties food = this.getFoodProperties(stack, null);
+        if (food == null) return;
+
+        food.effects().forEach(possibleEffect -> {
+            MobEffectInstance effect = possibleEffect.effect();
+            float chance = possibleEffect.probability();
+
+            Component line = Component.translatable(effect.getDescriptionId())
+                    .append(" ")
+                    .append(Component.literal("(" + (effect.getDuration() / 20) + "s)"))
+                    .withStyle(ChatFormatting.BLUE);
+
+            tooltip.add(line);
+        });
     }
 }

--- a/src/main/java/com/eeveebeby/farmersdelight_extended/item/custom_properties/ExtinguishFoodItem.java
+++ b/src/main/java/com/eeveebeby/farmersdelight_extended/item/custom_properties/ExtinguishFoodItem.java
@@ -1,12 +1,11 @@
 package com.eeveebeby.farmersdelight_extended.item.custom_properties;
 
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 
-public class ExtinguishFoodItem extends Item {
+public class ExtinguishFoodItem extends TooltipFoodItem {
     public ExtinguishFoodItem(Properties pProperties) {
         super(pProperties);
     }

--- a/src/main/java/com/eeveebeby/farmersdelight_extended/item/custom_properties/FartFoodItem.java
+++ b/src/main/java/com/eeveebeby/farmersdelight_extended/item/custom_properties/FartFoodItem.java
@@ -6,12 +6,11 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
 
-public class FartFoodItem extends Item {
+public class FartFoodItem extends TooltipFoodItem {
     public FartFoodItem(Properties properties) {
         super(properties);
     }

--- a/src/main/java/com/eeveebeby/farmersdelight_extended/item/custom_properties/SpicyFoodItem.java
+++ b/src/main/java/com/eeveebeby/farmersdelight_extended/item/custom_properties/SpicyFoodItem.java
@@ -1,12 +1,11 @@
 package com.eeveebeby.farmersdelight_extended.item.custom_properties;
 
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 
-public class SpicyFoodItem extends Item {
+public class SpicyFoodItem extends TooltipFoodItem {
     public SpicyFoodItem(Properties pProperties) {
         super(pProperties);
     }

--- a/src/main/java/com/eeveebeby/farmersdelight_extended/item/custom_properties/TooltipFoodItem.java
+++ b/src/main/java/com/eeveebeby/farmersdelight_extended/item/custom_properties/TooltipFoodItem.java
@@ -38,7 +38,7 @@ public class TooltipFoodItem extends Item {
             MutableComponent text = Component.translatable(effect.getDescriptionId());
 
             // Amplifier (I, II, III…)
-            if (effect.getAmplifier() >= 0) {
+            if (effect.getAmplifier() > 1) {
                 text = text.append(" ")
                         .append(Component.literal(toRoman(effect.getAmplifier() + 1)));
             }
@@ -63,7 +63,7 @@ public class TooltipFoodItem extends Item {
             if (chance < 1.0f) {
                 int percent = Math.round(chance * 100);
                 tooltip.add(
-                        Component.literal(" " + percent + "% chance")
+                        Component.literal(percent + "% chance")
                                 .withStyle(ChatFormatting.DARK_GRAY)
                 );
             }
@@ -81,7 +81,6 @@ public class TooltipFoodItem extends Item {
 
     private static String toRoman(int number) {
         return switch (number) {
-            case 1 -> "I";
             case 2 -> "II";
             case 3 -> "III";
             case 4 -> "IV";

--- a/src/main/java/com/eeveebeby/farmersdelight_extended/item/custom_properties/TooltipFoodItem.java
+++ b/src/main/java/com/eeveebeby/farmersdelight_extended/item/custom_properties/TooltipFoodItem.java
@@ -1,0 +1,97 @@
+package com.eeveebeby.farmersdelight_extended.item.custom_properties;
+
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.food.FoodProperties;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import org.jetbrains.annotations.NotNull;
+import net.minecraft.network.chat.MutableComponent;
+
+import java.util.List;
+
+public class TooltipFoodItem extends Item {
+
+    public TooltipFoodItem(Properties props) {
+        super(props);
+    }
+
+    @Override
+    public void appendHoverText(
+            @NotNull ItemStack stack,
+            @NotNull TooltipContext ctx,
+            @NotNull List<Component> tooltip,
+            @NotNull TooltipFlag flag
+    ) {
+        super.appendHoverText(stack, ctx, tooltip, flag);
+
+        FoodProperties food = getFoodProperties(stack, null);
+        if (food == null) return;
+
+        for (var entry : food.effects()) {
+            MobEffectInstance effect = entry.effect();
+            float chance = entry.probability();
+
+            // Base effect name (localized)
+            MutableComponent text = Component.translatable(effect.getDescriptionId());
+
+            // Amplifier (I, II, III…)
+            if (effect.getAmplifier() >= 0) {
+                text = text.append(" ")
+                        .append(Component.literal(toRoman(effect.getAmplifier() + 1)));
+            }
+
+            // Duration (MM:SS), only if > 1s
+            if (effect.getDuration() > 20) {
+                text = text.append(Component.literal(
+                        " (" + formatDuration(effect.getDuration()) + ")"
+                ));
+            }
+
+            // Color like vanilla
+            if (effect.getEffect().value().isBeneficial()) {
+                text = text.withStyle(ChatFormatting.BLUE);
+            } else {
+                text = text.withStyle(ChatFormatting.RED);
+            }
+
+            tooltip.add(text);
+
+            // Chance line if < 100%
+            if (chance < 1.0f) {
+                int percent = Math.round(chance * 100);
+                tooltip.add(
+                        Component.literal(" " + percent + "% chance")
+                                .withStyle(ChatFormatting.DARK_GRAY)
+                );
+            }
+        }
+    }
+
+    // ---------- helpers ----------
+
+    private static String formatDuration(int ticks) {
+        int totalSeconds = ticks / 20;
+        int minutes = totalSeconds / 60;
+        int seconds = totalSeconds % 60;
+        return String.format("%02d:%02d", minutes, seconds);
+    }
+
+    private static String toRoman(int number) {
+        return switch (number) {
+            case 1 -> "I";
+            case 2 -> "II";
+            case 3 -> "III";
+            case 4 -> "IV";
+            case 5 -> "V";
+            case 6 -> "VI";
+            case 7 -> "VII";
+            case 8 -> "VIII";
+            case 9 -> "IX";
+            case 10 -> "X";
+            default -> String.valueOf(number);
+        };
+    }
+}


### PR DESCRIPTION
Adds standardized food effect tooltips to match other mods in the ecosystem.
Also fixes Golden Apple Cider to be always eatable (previously missed).